### PR TITLE
Update 04-absolute-imports-and-module-aliases.mdx

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/04-absolute-imports-and-module-aliases.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/04-absolute-imports-and-module-aliases.mdx
@@ -163,3 +163,7 @@ export default function HomePage() {
   )
 }
 ```
+Tell Visual Studio Code to always use non-relative paths for TypeScript auto imports
+```json filename="settings.json (workspace or user)"
+"typescript.preferences.importModuleSpecifier": "non-relative"
+```


### PR DESCRIPTION
### What?
Improving Documentation:
Added instructions on how to tell VS Code on using non-relative paths for import

### Why?
To help developers understand how they can use absolute imports in VSCode

### How?
By modifying `settings.json` file with `"typescript.preferences.importModuleSpecifier": "non-relative"`
